### PR TITLE
instances to include exporters only on port 9187

### DIFF
--- a/dashboards/postgresql-database.json
+++ b/dashboards/postgresql-database.json
@@ -3066,7 +3066,7 @@
         "options": [],
         "query": "query_result(up{release=\"$release\"})",
         "refresh": 1,
-        "regex": "/.*instance=\"([^\"]+).*/",
+        "regex": "/.*instance=\"([^\"]+.*9187)/",
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",


### PR DESCRIPTION
Hello and thank you for a great dashboard :)

Pro:
 - Reduce clutter and makes it easier to find the instances.

Con:
 - If someone is running the postgresql_exporter on a non-default port then it will not show up

Fixes #5